### PR TITLE
Add diff command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "type": "module",
   "dependencies": {
     "commander": "^11.1.0",
+    "deep-comparer": "^2.0.3",
     "jsonld": "^8.3.2",
     "jsonld-request": "^2.0.1"
   },


### PR DESCRIPTION
Expands two JSON-LD files and compares the expanded results.

This can be extremely useful when moving to a new context file that uses (some or all of) the same term definitions as the previous context file.

This introduces a dependency on [deep-comparer](https://www.npmjs.com/package/deep-comparer) which is ISC licensed.